### PR TITLE
Fix duplicated struct decoder

### DIFF
--- a/protobuf-solidity/src/protoc/plugin/gen_decoder.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder.py
@@ -126,7 +126,7 @@ def gen_struct_decoder(f, msg, parent_struct_name):
   )
 
 def gen_struct_decoders(msg, parent_struct_name):
-  return ''.join(list(map(
+  return ''.join(set(map(
     (lambda f: gen_struct_decoder(f, msg, parent_struct_name) if util.field_is_message(f) else ""), msg.field)))
 
 

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder.py
@@ -126,8 +126,8 @@ def gen_struct_decoder(f, msg, parent_struct_name):
   )
 
 def gen_struct_decoders(msg, parent_struct_name):
-  return ''.join(set(map(
-    (lambda f: gen_struct_decoder(f, msg, parent_struct_name) if util.field_is_message(f) else ""), msg.field)))
+  decoders = list(map((lambda f: gen_struct_decoder(f, msg, parent_struct_name) if util.field_is_message(f) else ""), msg.field))
+  return ''.join(sorted(set(decoders), key=decoders.index))
 
 
 def gen_decoder_section(msg, parent_struct_name, file):


### PR DESCRIPTION
Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>

fixes #3

This would work correctly, but I think it should be implemented to have a function table of scope and reference it.