### PR TITLE
stop warning about variable shadowing

### DIFF
--- a/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
+++ b/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
@@ -2868,10 +2868,12 @@ library ProtoBufRuntime {
     ) {
       realSize -= 1;
     }
-    int256 remainder = (x & (base << (realSize * BYTE_SIZE - BYTE_SIZE))) >>
-      (realSize * BYTE_SIZE - BYTE_SIZE);
-    if (remainder < 128) {
-      realSize += 1;
+    {
+      int256 remainder = (x & (base << (realSize * BYTE_SIZE - BYTE_SIZE))) >>
+        (realSize * BYTE_SIZE - BYTE_SIZE);
+      if (remainder < 128) {
+        realSize += 1;
+      }
     }
     return realSize;
   }


### PR DESCRIPTION
In this function the variable `remainder` is defined at two places, resulting in the shadowing warning.
This PR stops the warning by separating the scopes of the two variables. 

Signed-off-by: Masanori Yoshida <masanori.yoshida@datachain.jp>