### PR TITLE
support keyword literal fields

### DIFF
--- a/protobuf-solidity/src/protoc/plugin/gen_sol.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_sol.py
@@ -202,6 +202,7 @@ def gen_codec(msg: Descriptor, delegate_codecs: List[str]):
     utility_functions = gen_utility_functions(msg)
   ))
   for nested in msg.nested_types:
+    nested = nested if not util.ALLOW_RESERVED_KEYWORDS else util.MessageWrapper(nested)
     gen_codec(nested, delegate_codecs)
 
 def gen_global_enum(file: FileDescriptor, delegate_codecs: List[str]):
@@ -256,6 +257,8 @@ def apply_options(params_string):
     COMPILE_META_SCHEMA = True
   if "solc_version" in params:
     util.set_solc_version(params["solc_version"])
+  if "allow_reserved_keywords" in params:
+    util.set_allow_reserved_keywords(True)
 
 def change_runtime_file_names(name: str):
   if not name.endswith(".sol"):
@@ -334,6 +337,7 @@ def generate_code(request, response):
     # generate per message codes
     delegate_codecs = []
     for msg in proto_file.message_types_by_name.values():
+      msg = msg if not util.ALLOW_RESERVED_KEYWORDS else util.MessageWrapper(msg)
       gen_codec(msg, delegate_codecs)
     if len(proto_file.enum_types_by_name):
       gen_global_enum(proto_file, delegate_codecs)


### PR DESCRIPTION
## Problem
Currently, the protobuf compiler doesn't recognize reserved keywords, resulting in field names that won't compile (ex. `seconds`, `bytes`, `block` etc.)

## Solution
At user request (via `allow_reserved_keywords` protoc flag) user lets the user know that the reserved keywords are intended. The resulting compiled code will now capitalize the keyword, to avoid the compiler error. For example:
```
message Duration {
  int64 seconds = 1;
  int32 nanos = 2;
}
```

compiles to:
```
struct Data {
 int64 Seconds;
 int32 nanos;
}
```

### Note on the implementation
The `Message` / `Descriptor` objects are immutable (referring to CPython code) therefore it's not possible to simply override `msg.fields` class member. I created a passthrough class to override the field names when neccecary.