### PR TITLE
Support packed repeated fields

### DIFF
--- a/contracts/TestRepeatedNative.sol
+++ b/contracts/TestRepeatedNative.sol
@@ -7,7 +7,8 @@ contract TestRepeatedNative {
     uint256[] uint256s;
     int64[] sint64s;
     bool bool_field;
-
+    int32[] unpacked_int32s;
+    int32[] packed_int32s;
   }
   mapping(address => Data) public contracts;
 
@@ -27,11 +28,32 @@ contract TestRepeatedNative {
     return contracts[key].sint64s;
   }
 
-  function storeTestRepeated(address key, string memory string_field,
-    uint256[] memory uint256s, int64[] memory sint64s,
-    bool bool_field) public {
-      Data memory data = Data({string_field: string_field, uint256s: uint256s,
-        sint64s: sint64s, bool_field: bool_field});
-      contracts[key] = data;
+
+  function getTestRepeatedUnpackedInt32(address key) public view returns (int32[] memory) {
+    return contracts[key].unpacked_int32s;
+  }
+
+  function getTestRepeatedPackedInt32(address key) public view returns (int32[] memory) {
+    return contracts[key].packed_int32s;
+  }
+
+  function storeTestRepeated(
+    address key,
+    string memory string_field,
+    uint256[] memory uint256s,
+    int64[] memory sint64s,
+    bool bool_field,
+    int32[] memory unpacked_int32s,
+    int32[] memory packed_int32s
+  ) public {
+    Data memory data = Data({
+      string_field: string_field,
+      uint256s: uint256s,
+      sint64s: sint64s,
+      bool_field: bool_field,
+      unpacked_int32s: unpacked_int32s,
+      packed_int32s: packed_int32s
+    });
+    contracts[key] = data;
   }
 }

--- a/contracts/TestRepeatedPB.sol
+++ b/contracts/TestRepeatedPB.sol
@@ -33,12 +33,38 @@ contract TestRepeatedPB {
     return data.sint64s;
   }
 
-  function storeTestRepeated(address key, string memory string_field,
-    uint256[] memory uint256s, int64[] memory sint64s,
-    bool bool_field) public {
-      TestRepeated.Data memory data = TestRepeated.Data({string_field: string_field, uint256s: uint256s,
-        sint64s: sint64s, bool_field: bool_field});
-      bytes memory encoded = TestRepeated.encode(data);
-      ProtoBufRuntime.encodeStorage(contracts[key], encoded);
+  function getTestRepeatedUnpackedInt32(address key) public view returns (int32[] memory) {
+    bytes storage location = contracts[key];
+    bytes memory encoded = ProtoBufRuntime.decodeStorage(location);
+    TestRepeated.Data memory data = TestRepeated.decode(encoded);
+    return data.unpacked_int32s;
+  }
+
+  function getTestRepeatedPackedInt32(address key) public view returns (int32[] memory) {
+    bytes storage location = contracts[key];
+    bytes memory encoded = ProtoBufRuntime.decodeStorage(location);
+    TestRepeated.Data memory data = TestRepeated.decode(encoded);
+    return data.packed_int32s;
+  }
+
+  function storeTestRepeated(
+    address key,
+    string memory string_field,
+    uint256[] memory uint256s,
+    int64[] memory sint64s,
+    bool bool_field,
+    int32[] memory unpacked_int32s,
+    int32[] memory packed_int32s
+  ) public {
+    TestRepeated.Data memory data = TestRepeated.Data({
+      string_field: string_field,
+      uint256s: uint256s,
+      sint64s: sint64s,
+      bool_field: bool_field,
+      unpacked_int32s: unpacked_int32s,
+      packed_int32s: packed_int32s
+    });
+    bytes memory encoded = TestRepeated.encode(data);
+    ProtoBufRuntime.encodeStorage(contracts[key], encoded);
   }
 }

--- a/contracts/TestRepeatedTwoPB.sol
+++ b/contracts/TestRepeatedTwoPB.sol
@@ -33,12 +33,38 @@ contract TestRepeatedTwoPB {
     return data.sint64s;
   }
 
-  function storeTestRepeated(address key, string memory string_field,
-    uint256[] memory uint256s, int64[] memory sint64s,
-    bool bool_field) public {
-      TestRepeatedTwo.Data memory data = TestRepeatedTwo.Data({string_field: string_field, uint256s: uint256s,
-        sint64s: sint64s, bool_field: bool_field});
-      bytes memory encoded = TestRepeatedTwo.encode(data);
-      ProtoBufRuntime.encodeStorage(contracts[key], encoded);
+  function getTestRepeatedUnpackedInt32(address key) public view returns (int32[] memory) {
+    bytes storage location = contracts[key];
+    bytes memory encoded = ProtoBufRuntime.decodeStorage(location);
+    TestRepeatedTwo.Data memory data = TestRepeatedTwo.decode(encoded);
+    return data.unpacked_int32s;
+  }
+
+  function getTestRepeatedPackedInt32(address key) public view returns (int32[] memory) {
+    bytes storage location = contracts[key];
+    bytes memory encoded = ProtoBufRuntime.decodeStorage(location);
+    TestRepeatedTwo.Data memory data = TestRepeatedTwo.decode(encoded);
+    return data.packed_int32s;
+  }
+
+  function storeTestRepeated(
+    address key,
+    string memory string_field,
+    uint256[] memory uint256s,
+    int64[] memory sint64s,
+    bool bool_field,
+    int32[] memory unpacked_int32s,
+    int32[] memory packed_int32s
+  ) public {
+    TestRepeatedTwo.Data memory data = TestRepeatedTwo.Data({
+      string_field: string_field,
+      uint256s: uint256s,
+      sint64s: sint64s,
+      bool_field: bool_field,
+      unpacked_int32s: unpacked_int32s,
+      packed_int32s: packed_int32s
+    });
+    bytes memory encoded = TestRepeatedTwo.encode(data);
+    ProtoBufRuntime.encodeStorage(contracts[key], encoded);
   }
 }

--- a/proto/test_repeated.proto
+++ b/proto/test_repeated.proto
@@ -6,4 +6,6 @@ message TestRepeated {
   repeated .solidity.uint256 uint256s = 2;
   repeated .solidity.int64 sint64s = 3;
   bool bool_field = 4;
+  repeated int32 unpacked_int32s = 5 [packed=false];
+  repeated int32 packed_int32s = 6 [packed=true];
 }

--- a/proto/test_repeated_two.proto
+++ b/proto/test_repeated_two.proto
@@ -6,4 +6,6 @@ message TestRepeatedTwo {
   repeated .solidity.uint256 uint256s = 2;
   repeated sint64 sint64s = 3;
   bool bool_field = 4;
+  repeated int32 unpacked_int32s = 5 [packed=false];
+  repeated int32 packed_int32s = 6 [packed=true];
 }

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder.py
@@ -20,17 +20,31 @@ def gen_inner_field_decoder(field: FieldDescriptor, first_pass: bool, index: int
       args = decoder_constants.INNER_FIELD_DECODER_NIL
     else:
       args = decoder_constants.INNER_FIELD_DECODER_REGULAR
+    if util.field_is_scalar_numeric(field):
+      return (decoder_constants.INNER_REPEATED_SCALAR_NUMERIC_FIELD_DECODER).format(
+        control = ("else " if index > 0 else ""),
+        id = field.number,
+        field = field.name,
+        args = args
+      )
+    else:
+      return (decoder_constants.INNER_FIELD_DECODER).format(
+        control = ("else " if index > 0 else ""),
+        id = field.number,
+        field = field.name,
+        args = args
+      )
   else:
     if first_pass:
       args = decoder_constants.INNER_FIELD_DECODER_REGULAR
     else:
       args = decoder_constants.INNER_FIELD_DECODER_NIL
-  return (decoder_constants.INNER_FIELD_DECODER).format(
-    control = ("else " if index > 0 else ""),
-    id = field.number,
-    field = field.name,
-    args = args
-  )
+    return (decoder_constants.INNER_FIELD_DECODER).format(
+      control = ("else " if index > 0 else ""),
+      id = field.number,
+      field = field.name,
+      args = args
+    )
 
 def gen_inner_fields_decoder(msg: Descriptor, first_pass: bool) -> str:
   transformed = [gen_inner_field_decoder(field, first_pass, index) for index, field in enumerate(msg.fields)]

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
@@ -135,13 +135,12 @@ FIELD_READER = """
   }}
 """
 
-PACKED_REPEATED_FIELD_READER = """
+PACKED_REPEATED_FIXED32_FIELD_READER = """
   /**
    * @dev The decoder for reading a field
    * @param p The offset of bytes array to start decode
    * @param bs The bytes array to be decoded
    * @param r The in-memory struct
-   * @param wireType The wire type of the field
    * @param counters The counters for repeated fields
    * @return The number of bytes decoded
    */
@@ -149,7 +148,6 @@ PACKED_REPEATED_FIELD_READER = """
     uint256 p,
     bytes memory bs,
     {t} memory r,
-    ProtoBufRuntime.WireType wireType,
     uint[{n}] memory counters
   ) internal pure returns (uint) {{
     /**
@@ -161,15 +159,79 @@ PACKED_REPEATED_FIELD_READER = """
       return size + len;
     }}
     p += size;
-    uint256 count;
-    if (wireType == ProtoBufRuntime.WireType.Fixed32) {{
-      count = len / 4;
-    }} else if (wireType == ProtoBufRuntime.WireType.Fixed64) {{
-      count = len / 8;
-    }} else {{
-      require(wireType == ProtoBufRuntime.WireType.Varint);
-      count = ProtoBufRuntime._count_packed_repeated_varint(p, len, bs);
+    uint256 count = len / 4;
+    r.{field} = new {decode_type}[](count);
+    for (uint256 i = 0; i < count; i++) {{
+      ({decode_type} x, uint256 sz) = {decoder}(p, bs);
+      p += sz;
+      r.{field}[i] = x;
     }}
+    if (counters[{i}] > 0) counters[{i}] -= 1;
+    return size + len;
+  }}
+"""
+
+PACKED_REPEATED_FIXED64_FIELD_READER = """
+  /**
+   * @dev The decoder for reading a field
+   * @param p The offset of bytes array to start decode
+   * @param bs The bytes array to be decoded
+   * @param r The in-memory struct
+   * @param counters The counters for repeated fields
+   * @return The number of bytes decoded
+   */
+  function _read_packed_repeated_{field}(
+    uint256 p,
+    bytes memory bs,
+    {t} memory r,
+    uint[{n}] memory counters
+  ) internal pure returns (uint) {{
+    /**
+     * if `r` is NULL, then only counting the number of fields.
+     */
+    (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(p, bs);
+    if (isNil(r)) {{
+      counters[{i}] += 1;
+      return size + len;
+    }}
+    p += size;
+    uint256 count = len / 8;
+    r.{field} = new {decode_type}[](count);
+    for (uint256 i = 0; i < count; i++) {{
+      ({decode_type} x, uint256 sz) = {decoder}(p, bs);
+      p += sz;
+      r.{field}[i] = x;
+    }}
+    if (counters[{i}] > 0) counters[{i}] -= 1;
+    return size + len;
+  }}
+"""
+
+PACKED_REPEATED_VARINT_FIELD_READER = """
+  /**
+   * @dev The decoder for reading a field
+   * @param p The offset of bytes array to start decode
+   * @param bs The bytes array to be decoded
+   * @param r The in-memory struct
+   * @param counters The counters for repeated fields
+   * @return The number of bytes decoded
+   */
+  function _read_packed_repeated_{field}(
+    uint256 p,
+    bytes memory bs,
+    {t} memory r,
+    uint[{n}] memory counters
+  ) internal pure returns (uint) {{
+    /**
+     * if `r` is NULL, then only counting the number of fields.
+     */
+    (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(p, bs);
+    if (isNil(r)) {{
+      counters[{i}] += 1;
+      return size + len;
+    }}
+    p += size;
+    uint256 count = ProtoBufRuntime._count_packed_repeated_varint(p, len, bs);
     r.{field} = new {decode_type}[](count);
     for (uint256 i = 0; i < count; i++) {{
       ({decode_type} x, uint256 sz) = {decoder}(p, bs);

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
@@ -68,24 +68,18 @@ INNER_DECODER = """
 INNER_DECODER_ELSE = """
       else {{
         if (wireType == ProtoBufRuntime.WireType.Fixed64) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_fixed64(pointer, bs);
-          pointer += size;
+          pointer += 8;
         }}
         if (wireType == ProtoBufRuntime.WireType.Fixed32) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_fixed32(pointer, bs);
-          pointer += size;
+          pointer += 4;
         }}
         if (wireType == ProtoBufRuntime.WireType.Varint) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_varint(pointer, bs);
+          (, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
           pointer += size;
         }}
         if (wireType == ProtoBufRuntime.WireType.LengthDelim) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_lendelim(pointer, bs);
-          pointer += size;
+          (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
+          pointer += size + len;
         }}
       }}
 """
@@ -96,24 +90,18 @@ INNER_DECODER_SECOND_PASS = """
       pointer += bytesRead;{second_pass}
       else {{
         if (wireType == ProtoBufRuntime.WireType.Fixed64) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_fixed64(pointer, bs);
-          pointer += size;
+          pointer += 8;
         }}
         if (wireType == ProtoBufRuntime.WireType.Fixed32) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_fixed32(pointer, bs);
-          pointer += size;
+          pointer += 4;
         }}
         if (wireType == ProtoBufRuntime.WireType.Varint) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_varint(pointer, bs);
+          (, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
           pointer += size;
         }}
         if (wireType == ProtoBufRuntime.WireType.LengthDelim) {{
-          uint256 size;
-          (, size) = ProtoBufRuntime._decode_lendelim(pointer, bs);
-          pointer += size;
+          (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
+          pointer += size + len;
         }}
       }}
     }}"""

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
@@ -301,7 +301,7 @@ UNPACKED_REPEATED_ENUM_FIELD_READER = """
       counters[{i}] += 1;
     }} else {{
       r.{field}[r.{field}.length - counters[{i}]] = x;
-      if(counters[{i}] > 0) counters[{i}] -= 1;
+      counters[{i}] -= 1;
     }}
     return sz;
   }}

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
@@ -92,20 +92,7 @@ INNER_DECODER = """
 
 INNER_DECODER_ELSE = """
       {{
-        if (wireType == ProtoBufRuntime.WireType.Fixed64) {{
-          pointer += 8;
-        }}
-        if (wireType == ProtoBufRuntime.WireType.Fixed32) {{
-          pointer += 4;
-        }}
-        if (wireType == ProtoBufRuntime.WireType.Varint) {{
-          (, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
-          pointer += size;
-        }}
-        if (wireType == ProtoBufRuntime.WireType.LengthDelim) {{
-          (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
-          pointer += size + len;
-        }}
+        pointer += ProtoBufRuntime._skip_field(wireType, pointer, bs);
       }}
 """
 INNER_DECODER_SECOND_PASS = """
@@ -114,20 +101,7 @@ INNER_DECODER_SECOND_PASS = """
       (fieldId, wireType, bytesRead) = ProtoBufRuntime._decode_key(pointer, bs);
       pointer += bytesRead;{second_pass}
       {{
-        if (wireType == ProtoBufRuntime.WireType.Fixed64) {{
-          pointer += 8;
-        }}
-        if (wireType == ProtoBufRuntime.WireType.Fixed32) {{
-          pointer += 4;
-        }}
-        if (wireType == ProtoBufRuntime.WireType.Varint) {{
-          (, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
-          pointer += size;
-        }}
-        if (wireType == ProtoBufRuntime.WireType.LengthDelim) {{
-          (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(pointer, bs);
-          pointer += size + len;
-        }}
+        pointer += ProtoBufRuntime._skip_field(wireType, pointer, bs);
       }}
     }}"""
 

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
@@ -92,7 +92,7 @@ INNER_DECODER = """
 
 INNER_DECODER_ELSE = """
       {{
-        pointer += ProtoBufRuntime._skip_field(wireType, pointer, bs);
+        pointer += ProtoBufRuntime._skip_field_decode(wireType, pointer, bs);
       }}
 """
 INNER_DECODER_SECOND_PASS = """
@@ -101,7 +101,7 @@ INNER_DECODER_SECOND_PASS = """
       (fieldId, wireType, bytesRead) = ProtoBufRuntime._decode_key(pointer, bs);
       pointer += bytesRead;{second_pass}
       {{
-        pointer += ProtoBufRuntime._skip_field(wireType, pointer, bs);
+        pointer += ProtoBufRuntime._skip_field_decode(wireType, pointer, bs);
       }}
     }}"""
 

--- a/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_decoder_constants.py
@@ -24,6 +24,15 @@ MAIN_DECODER = """
     store(x, self);
   }}"""
 
+INNER_REPEATED_SCALAR_NUMERIC_FIELD_DECODER = """
+      {control}if (fieldId == {id}) {{
+        if (wireType == ProtoBufRuntime.WireType.LengthDelim) {{
+          pointer += _read_packed_repeated_{field}({args});
+        }} else {{
+          pointer += _read_{field}({args});
+        }}
+      }}"""
+
 INNER_FIELD_DECODER = """
       {control}if (fieldId == {id}) {{
         pointer += _read_{field}({args});

--- a/protobuf-solidity/src/protoc/plugin/gen_encoder.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_encoder.py
@@ -123,8 +123,10 @@ def gen_field_estimator(f: FieldDescriptor, msg: Descriptor) -> str:
   if util.field_is_repeated(f):
     if util.is_map_type(f):
       template = encoder_constants.FIELD_ESTIMATOR_REPEATED_MAP
+    elif util.field_is_packed(f):
+      template = encoder_constants.FIELD_ESTIMATOR_PACKED_REPEATED
     else:
-      template = encoder_constants.FIELD_ESTIMATOR_REPEATED
+      template = encoder_constants.FIELD_ESTIMATOR_UNPACKED_REPEATED
   else:
     template = encoder_constants.FIELD_ESTIMATOR_NOT_REPEATED
   return template.format(

--- a/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
@@ -126,7 +126,16 @@ NESTED_ENCODER = """
     return pointer - offset;
   }}"""
 
-FIELD_ESTIMATOR_REPEATED = """
+FIELD_ESTIMATOR_PACKED_REPEATED = """
+    {{
+      uint256 e_body = 0;
+      for(i = 0; i < r.{field}.length; i++) {{
+        e_body += {szItem};
+      }}
+      e += {szKey} + ProtoBufRuntime._sz_lendelim(e_body);
+    }}"""
+
+FIELD_ESTIMATOR_UNPACKED_REPEATED = """
     for(i = 0; i < r.{field}.length; i++) {{
       e += {szKey} + {szItem};
     }}"""

--- a/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
@@ -13,7 +13,7 @@ MAIN_ENCODER = """
     return bs;
   }}"""
 
-INNER_FIELD_ENCODER_REPEATED = """
+INNER_FIELD_ENCODER_UNPACKED_REPEATED = """
     {block_begin}
     for(i = 0; i < r.{field}.length; i++) {{
       pointer += ProtoBufRuntime._encode_key(
@@ -26,7 +26,7 @@ INNER_FIELD_ENCODER_REPEATED = """
     }}
     {block_end}"""
 
-INNER_FIELD_ENCODER_REPEATED_ENUM = """
+INNER_FIELD_ENCODER_UNPACKED_REPEATED_ENUM = """
     {block_begin}
     int32 _enum_{field};
     for(i = 0; i < r.{field}.length; i++) {{
@@ -51,6 +51,43 @@ INNER_FIELD_ENCODER_REPEATED_MAP = """
         bs
       );
       pointer += {encoder}(r.{field}[i], pointer, bs);
+    }}
+    {block_end}"""
+
+INNER_FIELD_ENCODER_PACKED_REPEATED = """
+    {block_begin}
+    pointer += ProtoBufRuntime._encode_key(
+      {key},
+      ProtoBufRuntime.WireType.LengthDelim,
+      pointer,
+      bs
+    );
+    pointer += ProtoBufRuntime._encode_varint(
+      {size},
+      pointer,
+      bs
+    );
+    for(i = 0; i < r.{field}.length; i++) {{
+      pointer += {encoder}(r.{field}[i], pointer, bs);
+    }}
+    {block_end}"""
+
+INNER_FIELD_ENCODER_PACKED_REPEATED_ENUM = """
+    {block_begin}
+    pointer += ProtoBufRuntime._encode_key(
+      {key},
+      ProtoBufRuntime.WireType.LengthDelim,
+      pointer,
+      bs
+    );
+    pointer += ProtoBufRuntime._encode_varint(
+      {size},
+      pointer,
+      bs
+    );
+    for(i = 0; i < r.{field}.length; i++) {{
+      int32 _enum_{field} = {library_name}encode_{enum_name}(r.{field}[i]);
+      pointer += {encoder}(_enum_{field}, pointer, bs);
     }}
     {block_end}"""
 

--- a/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
@@ -126,16 +126,7 @@ NESTED_ENCODER = """
     return pointer - offset;
   }}"""
 
-FIELD_ESTIMATOR_PACKED_REPEATED = """
-    {{
-      uint256 e_body = 0;
-      for(i = 0; i < r.{field}.length; i++) {{
-        e_body += {szItem};
-      }}
-      e += {szKey} + ProtoBufRuntime._sz_lendelim(e_body);
-    }}"""
-
-FIELD_ESTIMATOR_UNPACKED_REPEATED = """
+FIELD_ESTIMATOR_REPEATED = """
     for(i = 0; i < r.{field}.length; i++) {{
       e += {szKey} + {szItem};
     }}"""

--- a/protobuf-solidity/src/protoc/plugin/gen_util.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_util.py
@@ -228,6 +228,10 @@ def field_is_repeated(f: FieldDescriptor) -> bool:
 def field_is_scalar_numeric(f: FieldDescriptor) -> bool:
   return gen_wire_type(f) in ['Varint', 'Fixed32', 'Fixed64']
 
+def field_is_packed(f: FieldDescriptor) -> bool:
+  opt = f.GetOptions()
+  return opt.packed or field_is_scalar_numeric(f) and not opt.HasField("packed")
+
 def field_has_dyn_size(f: FieldDescriptor) -> bool:
   # if string or bytes, dynamic
   if f.type == FieldDescriptor.TYPE_STRING or f.type == FieldDescriptor.TYPE_BYTES:

--- a/protobuf-solidity/src/protoc/plugin/gen_util.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_util.py
@@ -225,6 +225,9 @@ def field_is_message(f: FieldDescriptor) -> bool:
 def field_is_repeated(f: FieldDescriptor) -> bool:
   return f.label == FieldDescriptor.LABEL_REPEATED
 
+def field_is_scalar_numeric(f: FieldDescriptor) -> bool:
+  return gen_wire_type(f) in ['Varint', 'Fixed32', 'Fixed64']
+
 def field_has_dyn_size(f: FieldDescriptor) -> bool:
   # if string or bytes, dynamic
   if f.type == FieldDescriptor.TYPE_STRING or f.type == FieldDescriptor.TYPE_BYTES:

--- a/protobuf-solidity/src/protoc/plugin/gen_util.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_util.py
@@ -433,7 +433,10 @@ def gen_enumtype(e: EnumDescriptor) -> str:
       enum_name = e.name,
       enum_values = gen_enum_decoders(e)
     )
-    return definition + "\n" + encoder + "\n" + decoder
+    estimator = util_constants.ENUM_ESTIMATE_FUNCTION.format(
+      enum_name = e.name
+    )
+    return definition + "\n" + encoder + "\n" + decoder + "\n" + estimator
 
 def gen_struct_decoder_name_from_field(field: FieldDescriptor) -> str:
   ftid, _ = gen_field_type_id(field)

--- a/protobuf-solidity/src/protoc/plugin/gen_util_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_util_constants.py
@@ -34,6 +34,21 @@ ENUM_DECODE_FUNCTION = """
   }}
 """
 
+ENUM_ESTIMATE_FUNCTION = """
+  /**
+   * @dev The estimator for an packed enum array
+   * @return The number of bytes encoded
+   */
+  function estimate_packed_repeated_{enum_name}(
+    {enum_name}[] memory a
+  ) internal pure returns (uint256) {{
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {{
+      e += ProtoBufRuntime._sz_enum(encode_{enum_name}(a[i]));
+    }}
+    return e;
+  }}"""
+
 ENUM_DECODE_FUNCTION_INNER = """
     if (x == {value}) {{
       return {enum_name}.{name};

--- a/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
+++ b/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
@@ -946,16 +946,6 @@ library ProtoBufRuntime {
     }
     return count;
   }
-  function _count_packed_repeated_lendelim(uint256 p, uint256 len, bytes memory bs) internal pure returns (uint256) {
-    uint256 count = 0;
-    uint256 end = p + len;
-    while (p < end) {
-      (uint256 l, uint256 sz) = _decode_varint(p, bs);
-      p += sz + l;
-      count += 1;
-    }
-    return count;
-  }
 
   // Soltype extensions
   /**

--- a/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
+++ b/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
@@ -934,6 +934,29 @@ library ProtoBufRuntime {
     return _sz_varint(_encode_zigzag(i));
   }
 
+  // Element counters for packed repeated fields
+  function _count_packed_repeated_varint(uint256 p, uint256 len, bytes memory bs) internal pure returns (uint256) {
+    uint256 count = 0;
+    uint256 end = p + len;
+    while (p < end) {
+      uint256 sz;
+      (, sz) = _decode_varint(p, bs);
+      p += sz;
+      count += 1;
+    }
+    return count;
+  }
+  function _count_packed_repeated_lendelim(uint256 p, uint256 len, bytes memory bs) internal pure returns (uint256) {
+    uint256 count = 0;
+    uint256 end = p + len;
+    while (p < end) {
+      (uint256 l, uint256 sz) = _decode_varint(p, bs);
+      p += sz + l;
+      count += 1;
+    }
+    return count;
+  }
+
   // Soltype extensions
   /**
    * @dev Decode Solidity integer and/or fixed-size bytes array, filling from lowest bit.

--- a/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
+++ b/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
@@ -560,13 +560,13 @@ library ProtoBufRuntime {
   }
 
   /**
-   * @dev Skip one field
+   * @dev Skip the decoding of a single field
    * @param wt The WireType of the field
    * @param p The memory offset of `bs`
    * @param bs The bytes array to be decoded
    * @return The length of `bs` to skipped
    */
-  function _skip_field(WireType wt, uint256 p, bytes memory bs)
+  function _skip_field_decode(WireType wt, uint256 p, bytes memory bs)
     internal
     pure
     returns (uint256)

--- a/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
+++ b/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
@@ -559,6 +559,32 @@ library ProtoBufRuntime {
     return (b, sz + len);
   }
 
+  /**
+   * @dev Skip one field
+   * @param wt The WireType of the field
+   * @param p The memory offset of `bs`
+   * @param bs The bytes array to be decoded
+   * @return The length of `bs` to skipped
+   */
+  function _skip_field(WireType wt, uint256 p, bytes memory bs)
+    internal
+    pure
+    returns (uint256)
+  {
+    if (wt == ProtoBufRuntime.WireType.Fixed64) {
+      return 8;
+    } else if (wt == ProtoBufRuntime.WireType.Fixed32) {
+      return 4;
+    } else if (wt == ProtoBufRuntime.WireType.Varint) {
+      (, uint256 size) = ProtoBufRuntime._decode_varint(p, bs);
+      return size;
+    } else {
+      require(wt == ProtoBufRuntime.WireType.LengthDelim);
+      (uint256 len, uint256 size) = ProtoBufRuntime._decode_varint(p, bs);
+      return size + len;
+    }
+  }
+
   // Encoders
   /**
    * @dev Encode ProtoBuf key

--- a/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
+++ b/protobuf-solidity/src/protoc/plugin/runtime/ProtoBufRuntime.sol
@@ -960,6 +960,57 @@ library ProtoBufRuntime {
     return _sz_varint(_encode_zigzag(i));
   }
 
+  /**
+   * `_estimate_packed_repeated_(uint32|uint64|int32|int64|sint32|sint64)`
+   */
+  function _estimate_packed_repeated_uint32(uint32[] memory a) internal pure returns (uint256) {
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {
+      e += _sz_uint32(a[i]);
+    }
+    return e;
+  }
+
+  function _estimate_packed_repeated_uint64(uint64[] memory a) internal pure returns (uint256) {
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {
+      e += _sz_uint64(a[i]);
+    }
+    return e;
+  }
+
+  function _estimate_packed_repeated_int32(int32[] memory a) internal pure returns (uint256) {
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {
+      e += _sz_int32(a[i]);
+    }
+    return e;
+  }
+
+  function _estimate_packed_repeated_int64(int64[] memory a) internal pure returns (uint256) {
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {
+      e += _sz_int64(a[i]);
+    }
+    return e;
+  }
+
+  function _estimate_packed_repeated_sint32(int32[] memory a) internal pure returns (uint256) {
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {
+      e += _sz_sint32(a[i]);
+    }
+    return e;
+  }
+
+  function _estimate_packed_repeated_sint64(int64[] memory a) internal pure returns (uint256) {
+    uint256 e = 0;
+    for (uint i = 0; i < a.length; i++) {
+      e += _sz_sint64(a[i]);
+    }
+    return e;
+  }
+
   // Element counters for packed repeated fields
   function _count_packed_repeated_varint(uint256 p, uint256 len, bytes memory bs) internal pure returns (uint256) {
     uint256 count = 0;

--- a/run.sh
+++ b/run.sh
@@ -81,4 +81,9 @@ then
 fi
 
 parentdir="$(dirname "$_arg_input")"
-protoc -I$parentdir -I$(pwd)/protobuf-solidity/src/protoc/include --plugin=protoc-gen-sol=$(pwd)/protobuf-solidity/src/protoc/plugin/gen_sol.py --sol_out=gen_runtime=ProtoBufRuntime.sol:$_arg_output $_arg_input
+plugindir="$(dirname "$0")/protobuf-solidity/src/protoc"
+protoc \
+	-I"$parentdir" \
+	-I"$plugindir/include" \
+	--plugin="protoc-gen-sol=$plugindir/plugin/gen_sol.py" \
+	--sol_out=gen_runtime=ProtoBufRuntime.sol:$_arg_output $_arg_input

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+set -e
 rootdir="$(dirname "$0")"
 for file in $rootdir/proto/*
 do

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,14 @@
-#!/usr/bin/env bash
-set -e
-for file in proto/*
+rootdir="$(dirname "$0")"
+for file in $rootdir/proto/*
 do
   if [[ -f $file ]]; then
     echo "Generating "$file
-    protoc -I$(pwd)/proto -I$(pwd)/protobuf-solidity/src/protoc/include --plugin=protoc-gen-sol=$(pwd)/protobuf-solidity/src/protoc/plugin/gen_sol.py --"sol_out=gen_runtime=ProtoBufRuntime.sol&solc_version=0.8.10:$(pwd)/contracts/libs/" $(pwd)/$file
+    protoc \
+	    -I"$rootdir/proto" \
+	    -I"$rootdir/protobuf-solidity/src/protoc/include" \
+	    --plugin=protoc-gen-sol="$rootdir/protobuf-solidity/src/protoc/plugin/gen_sol.py" \
+	    --sol_out="gen_runtime=ProtoBufRuntime.sol&solc_version=0.8.10:$rootdir/contracts/libs/" \
+	    $file
   fi
 done
 

--- a/test/unit/testRepeatedNative.js
+++ b/test/unit/testRepeatedNative.js
@@ -12,20 +12,32 @@ contract('TestRepeatedNative', (accounts) => {
     let uint256s_expected = [1, 2, 3];
     let sint64s_expected = [-1, 2, -3];
     let bool_field_expected = true;
+    let unpacked_int32s_expected = [3, -2, 1, 0, -1000, 1000000, -1000000000];
+    let packed_int32s_expected = [-3, 2, -1, 0, 1000, -1000000, 1000000000];
 
-    await contractInstance.storeTestRepeated(accounts[0], string_field_expected,
-      uint256s_expected, sint64s_expected,
-      bool_field_expected);
+    await contractInstance.storeTestRepeated(
+      accounts[0],
+      string_field_expected,
+      uint256s_expected,
+      sint64s_expected,
+      bool_field_expected,
+      unpacked_int32s_expected,
+      packed_int32s_expected
+    );
 
     let string_field = await contractInstance.getTestRepeatedString(accounts[0]);
     let uint256s = await contractInstance.getTestRepeatedUint256(accounts[0]);
     let sint64s = await contractInstance.getTestRepeatedInt64(accounts[0]);
     let bool_field = await contractInstance.getTestRepeatedBool(accounts[0]);
+    let unpacked_int32s = await contractInstance.getTestRepeatedUnpackedInt32(accounts[0]);
+    let packed_int32s = await contractInstance.getTestRepeatedPackedInt32(accounts[0]);
 
     assert.equal(string_field_expected, string_field);
     assert.equal(JSON.stringify(uint256s_expected), JSON.stringify(uint256s.map(x => x.toNumber())));
     assert.equal(JSON.stringify(sint64s_expected), JSON.stringify(sint64s.map(x => x.toNumber())));
     assert.equal(bool_field_expected, bool_field);
+    assert.equal(JSON.stringify(unpacked_int32s_expected), JSON.stringify(unpacked_int32s.map(x => x.toNumber())));
+    assert.equal(JSON.stringify(packed_int32s_expected), JSON.stringify(packed_int32s.map(x => x.toNumber())));
 
   })
 });

--- a/test/unit/testRepeatedPB.js
+++ b/test/unit/testRepeatedPB.js
@@ -12,20 +12,32 @@ contract('TestRepeatedPB', (accounts) => {
     let uint256s_expected = [1, 2, 3];
     let sint64s_expected = [-1, 2, -3];
     let bool_field_expected = true;
+    let unpacked_int32s_expected = [3, -2, 1, 0, -1000, 1000000, -1000000000];
+    let packed_int32s_expected = [-3, 2, -1, 0, 1000, -1000000, 1000000000];
 
-    await contractInstance.storeTestRepeated(accounts[0], string_field_expected,
-      uint256s_expected, sint64s_expected,
-      bool_field_expected);
+    await contractInstance.storeTestRepeated(
+      accounts[0],
+      string_field_expected,
+      uint256s_expected,
+      sint64s_expected,
+      bool_field_expected,
+      unpacked_int32s_expected,
+      packed_int32s_expected
+    );
 
     let string_field = await contractInstance.getTestRepeatedString(accounts[0]);
     let uint256s = await contractInstance.getTestRepeatedUint256(accounts[0]);
     let sint64s = await contractInstance.getTestRepeatedInt64(accounts[0]);
     let bool_field = await contractInstance.getTestRepeatedBool(accounts[0]);
+    let unpacked_int32s = await contractInstance.getTestRepeatedUnpackedInt32(accounts[0]);
+    let packed_int32s = await contractInstance.getTestRepeatedPackedInt32(accounts[0]);
 
     assert.equal(string_field_expected, string_field);
     assert.equal(JSON.stringify(uint256s_expected), JSON.stringify(uint256s.map(x => x.toNumber())));
     assert.equal(JSON.stringify(sint64s_expected), JSON.stringify(sint64s.map(x => x.toNumber())));
     assert.equal(bool_field_expected, bool_field);
+    assert.equal(JSON.stringify(unpacked_int32s_expected), JSON.stringify(unpacked_int32s.map(x => x.toNumber())));
+    assert.equal(JSON.stringify(packed_int32s_expected), JSON.stringify(packed_int32s.map(x => x.toNumber())));
 
   })
 });

--- a/test/unit/testRepeatedTwoPB.js
+++ b/test/unit/testRepeatedTwoPB.js
@@ -12,20 +12,32 @@ contract('TestRepeatedTwoPB', (accounts) => {
     let uint256s_expected = [1, 2, 3];
     let sint64s_expected = [-1, 2, -3];
     let bool_field_expected = true;
+    let unpacked_int32s_expected = [3, -2, 1, 0, -1000, 1000000, -1000000000];
+    let packed_int32s_expected = [-3, 2, -1, 0, 1000, -1000000, 1000000000];
 
-    await contractInstance.storeTestRepeated(accounts[0], string_field_expected,
-      uint256s_expected, sint64s_expected,
-      bool_field_expected);
+    await contractInstance.storeTestRepeated(
+      accounts[0],
+      string_field_expected,
+      uint256s_expected,
+      sint64s_expected,
+      bool_field_expected,
+      unpacked_int32s_expected,
+      packed_int32s_expected
+    );
 
     let string_field = await contractInstance.getTestRepeatedString(accounts[0]);
     let uint256s = await contractInstance.getTestRepeatedUint256(accounts[0]);
     let sint64s = await contractInstance.getTestRepeatedInt64(accounts[0]);
     let bool_field = await contractInstance.getTestRepeatedBool(accounts[0]);
+    let unpacked_int32s = await contractInstance.getTestRepeatedUnpackedInt32(accounts[0]);
+    let packed_int32s = await contractInstance.getTestRepeatedPackedInt32(accounts[0]);
 
     assert.equal(string_field_expected, string_field);
     assert.equal(JSON.stringify(uint256s_expected), JSON.stringify(uint256s.map(x => x.toNumber())));
     assert.equal(JSON.stringify(sint64s_expected), JSON.stringify(sint64s.map(x => x.toNumber())));
     assert.equal(bool_field_expected, bool_field);
+    assert.equal(JSON.stringify(unpacked_int32s_expected), JSON.stringify(unpacked_int32s.map(x => x.toNumber())));
+    assert.equal(JSON.stringify(packed_int32s_expected), JSON.stringify(packed_int32s.map(x => x.toNumber())));
 
   })
 });


### PR DESCRIPTION
close #23 by:
- enabling to decode packed and unpacked repeated fields regardless of `[packed=...]` options
- enabling to encode packed and unpacked repeated fields according to `[packed=...]` options
    - If there's no option specified, scalar numeric repeated fields are encoded in a packed manner.