### PR TITLE
fix: add missing plugin path when generate

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -86,4 +86,4 @@ protoc \
 	-I"$parentdir" \
 	-I"$plugindir/include" \
 	--plugin="protoc-gen-sol=$plugindir/plugin/gen_sol.py" \
-	--sol_out=gen_runtime=ProtoBufRuntime.sol:$_arg_output $_arg_input
+	--sol_out=gen_runtime=$plugindir/plugin/runtime/ProtoBufRuntime.sol:$_arg_output $_arg_input


### PR DESCRIPTION
to avoid empty location in extract_npm_package_name_and_directory_path