### PR TITLE
Fix to comment out variable name if no checkers in `_empty` function

### DIFF
--- a/protobuf-solidity/src/protoc/plugin/gen_encoder.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_encoder.py
@@ -195,6 +195,7 @@ def gen_empty_field_checkers(msg: Descriptor) -> str:
 def gen_empty_checker(msg: Descriptor) -> str:
   return (encoder_constants.EMPTY_CHECKER).format(
     struct = util.gen_internal_struct_name(msg),
+    varname = "r" if len(gen_empty_field_checkers(msg)) > 0 else "/* r */",
     checkers = gen_empty_field_checkers(msg)
   )
 

--- a/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
+++ b/protobuf-solidity/src/protoc/plugin/gen_encoder_constants.py
@@ -190,7 +190,7 @@ ESTIMATOR = """
 
 EMPTY_CHECKER = """
   function _empty(
-    {struct} memory r
+    {struct} memory {varname}
   ) internal pure returns (bool) {{
     {checkers}
     return true;


### PR DESCRIPTION
This fixes the compile warnings such as https://github.com/hyperledger-labs/yui-ibc-solidity/actions/runs/7897706961/job/21553744606#step:7:13.